### PR TITLE
Add data reset feature

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -125,4 +125,16 @@ def get_daily_entry_by_date(db, user_id: int, date):
     return db.query(models.DailyEntry).filter(
         models.DailyEntry.user_id == user_id,
         models.DailyEntry.date == date
-    ).first() 
+    ).first()
+
+def reset_user_data(db: Session, user_id: int):
+    """Delete all trading data for the given user and reset balance."""
+    db.query(models.Deposit).filter(models.Deposit.user_id == user_id).delete(synchronize_session=False)
+    db.query(models.Withdrawal).filter(models.Withdrawal.user_id == user_id).delete(synchronize_session=False)
+    db.query(models.DailyEntry).filter(models.DailyEntry.user_id == user_id).delete(synchronize_session=False)
+
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if user:
+        user.active_balance = 0.0
+
+    db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -429,6 +429,15 @@ async def update_daily_entry(
         raise HTTPException(status_code=404, detail="Entry not found")
     return updated_entry
 
+
+@app.post("/reset-data")
+async def reset_data(
+    current_user: models.User = Depends(auth.get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    crud.reset_user_data(db, current_user.id)
+    return RedirectResponse(url="/dashboard", status_code=303)
+
 @app.get("/test")
 async def test():
     print("Test endpoint called")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,6 +29,12 @@
                         <a class="nav-link" href="/daily-entry">Daily Entry</a>
                     </li>
                 </ul>
+                {% if request.cookies.get('access_token') %}
+                <form class="d-flex ms-auto" action="/reset-data" method="post"
+                      onsubmit="return confirm('Are you sure you want to reset all data? This cannot be undone.');">
+                    <button class="btn btn-danger btn-sm" type="submit">Reset Data</button>
+                </form>
+                {% endif %}
             </div>
         </div>
     </nav>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -59,6 +59,7 @@
         </div>
     </div>
 
+
     <!-- Trading Calendar -->
     <div class="row mb-4">
         <div class="col-12">


### PR DESCRIPTION
## Summary
- add `reset_user_data` utility
- allow resetting data via `/reset-data` endpoint
- provide button on dashboard to trigger data reset
- show reset button only when logged in

## Testing
- `pytest -q`
- `flake8 || true`


------
https://chatgpt.com/codex/tasks/task_e_6840cdee0c748332a6e274b50c5bb3ab