### PR TITLE
Fix reset button visibility and db init

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -33,7 +33,5 @@ def get_db():
 
 def init_db():
     from . import models
-    # Drop all tables
-    models.Base.metadata.drop_all(bind=engine)
-    # Create all tables
-    models.Base.metadata.create_all(bind=engine) 
+    # Create tables if they do not exist
+    models.Base.metadata.create_all(bind=engine)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,7 +29,7 @@
                         <a class="nav-link" href="/daily-entry">Daily Entry</a>
                     </li>
                 </ul>
-                {% if request.cookies.get('access_token') %}
+                {% if request.cookies.get('access_token') and not hide_reset %}
                 <form class="d-flex ms-auto" action="/reset-data" method="post"
                       onsubmit="return confirm('Are you sure you want to reset all data? This cannot be undone.');">
                     <button class="btn btn-danger btn-sm" type="submit">Reset Data</button>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set hide_reset = True %}
 
 {% block content %}
 <div class="row justify-content-center">


### PR DESCRIPTION
## Summary
- hide reset button on the landing page
- only create DB tables instead of dropping them every start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d35dc0d483329182ec064bd2b9ca