### PR TITLE
Implement logout functionality

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -218,7 +218,7 @@ async def login(request: Request, db: Session = Depends(get_db)):
             samesite="lax"
         )
         return response
-        
+
     except Exception as e:
         print(f"Error: {str(e)}")
         import traceback
@@ -230,6 +230,13 @@ async def login(request: Request, db: Session = Depends(get_db)):
                 "error": f"Login failed: {str(e)}"
             }
         )
+
+
+@app.get("/logout")
+async def logout():
+    response = RedirectResponse(url="/")
+    response.delete_cookie("access_token")
+    return response
 
 @app.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,11 +29,18 @@
                         <a class="nav-link" href="/daily-entry">Daily Entry</a>
                     </li>
                 </ul>
-                {% if request.cookies.get('access_token') and not hide_reset %}
-                <form class="d-flex ms-auto" action="/reset-data" method="post"
-                      onsubmit="return confirm('Are you sure you want to reset all data? This cannot be undone.');">
-                    <button class="btn btn-danger btn-sm" type="submit">Reset Data</button>
-                </form>
+                {% if request.cookies.get('access_token') %}
+                <div class="d-flex ms-auto">
+                    {% if not hide_reset %}
+                    <form class="me-2" action="/reset-data" method="post"
+                          onsubmit="return confirm('Are you sure you want to reset all data? This cannot be undone.');">
+                        <button class="btn btn-danger btn-sm" type="submit">Reset Data</button>
+                    </form>
+                    {% endif %}
+                    {% if not hide_logout %}
+                    <a class="btn btn-outline-light btn-sm" href="/logout">Logout</a>
+                    {% endif %}
+                </div>
                 {% endif %}
             </div>
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set hide_reset = True %}
+{% set hide_logout = True %}
 
 {% block content %}
 <div class="row justify-content-center">


### PR DESCRIPTION
## Summary
- add `/logout` route that clears the auth cookie
- include Logout button in navbar when authenticated
- hide Logout button on the index page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d494d7588332b8b792d2485cfc0f