### PR TITLE
AJAX load for Gemini tips

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -239,4 +239,12 @@ body {
     font-weight: 600;
     margin-top: 1rem;
     margin-bottom: 1rem;
-} 
+}
+
+/* Loader */
+.loader-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 0;
+}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -82,7 +82,12 @@
                     <h5 class="mb-0">Trading Tips</h5>
                 </div>
                 <div class="card-body">
-                    <div>{{ trading_tips | safe }}</div>
+                    <div id="trading-tips-loader" class="loader-container">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                    <div id="trading-tips-content" style="display: none;"></div>
                 </div>
             </div>
         </div>
@@ -92,7 +97,12 @@
                     <h5 class="mb-0">Lessons Learned</h5>
                 </div>
                 <div class="card-body">
-                    <div>{{ lessons_learned | safe }}</div>
+                    <div id="lessons-learned-loader" class="loader-container">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                    <div id="lessons-learned-content" style="display: none;"></div>
                 </div>
             </div>
         </div>
@@ -179,6 +189,24 @@ document.addEventListener('DOMContentLoaded', function() {
         currentRow.appendChild(emptyDay);
     }
     calendar.appendChild(currentRow);
+
+    // Fetch trading insights via AJAX
+    fetch('/insights')
+        .then(response => response.json())
+        .then(data => {
+            document.getElementById('trading-tips-content').innerHTML = data.trading_tips;
+            document.getElementById('lessons-learned-content').innerHTML = data.lessons_learned;
+        })
+        .catch(() => {
+            document.getElementById('trading-tips-content').innerText = 'Failed to load insights.';
+            document.getElementById('lessons-learned-content').innerText = 'Failed to load insights.';
+        })
+        .finally(() => {
+            document.getElementById('trading-tips-loader').style.display = 'none';
+            document.getElementById('lessons-learned-loader').style.display = 'none';
+            document.getElementById('trading-tips-content').style.display = 'block';
+            document.getElementById('lessons-learned-content').style.display = 'block';
+        });
 });
 </script>
-{% endblock %} 
+{% endblock %}


### PR DESCRIPTION
## Summary
- speed up dashboard by computing AI insights via `/insights` endpoint
- add asynchronous loading of trading tips and lessons to dashboard
- show bootstrap spinner while waiting for data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684205a35c288332a46c1f387c3a9efb