### PR TITLE
Improve security with CSRF and sanitization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,8 @@ from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, RedirectResponse
+import secrets
+import bleach
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 import requests
@@ -24,6 +26,21 @@ templates = Jinja2Templates(directory="app/templates")
 
 # Mount static files
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+CSRF_COOKIE_NAME = "csrf_token"
+
+def generate_csrf_token() -> str:
+    return secrets.token_urlsafe(16)
+
+def set_csrf_cookie(response: HTMLResponse | RedirectResponse, token: str) -> None:
+    response.set_cookie(
+        CSRF_COOKIE_NAME,
+        token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=1800,
+    )
 
 # Gemini AI integration
 def get_gemini_insights(texts: list[str], prompt: str) -> str:
@@ -80,13 +97,22 @@ async def root(request: Request, access_token: str = Cookie(None), db: Session =
 
 @app.get("/register", response_class=HTMLResponse)
 async def register_page(request: Request):
-    return templates.TemplateResponse("register.html", {"request": request})
+    token = generate_csrf_token()
+    response = templates.TemplateResponse(
+        "register.html", {"request": request, "csrf_token": token}
+    )
+    set_csrf_cookie(response, token)
+    return response
 
 @app.post("/register")
 async def register(request: Request, db: Session = Depends(get_db)):
     print("\n=== Registration Request ===")
     try:
         form = await request.form()
+        form_csrf = form.get("csrf_token")
+        cookie_csrf = request.cookies.get(CSRF_COOKIE_NAME)
+        if not form_csrf or form_csrf != cookie_csrf:
+            raise HTTPException(status_code=403, detail="Invalid CSRF token")
         print(f"Form data: {dict(form)}")
         
         email = form.get("email")
@@ -100,41 +126,53 @@ async def register(request: Request, db: Session = Depends(get_db)):
         
         if not email or not username or not password:
             print("Error: Missing required fields")
-            return templates.TemplateResponse(
+            token = generate_csrf_token()
+            response = templates.TemplateResponse(
                 "register.html",
                 {
                     "request": request,
                     "error": "All fields are required.",
                     "email": email,
-                    "username": username
-                }
+                    "username": username,
+                    "csrf_token": token,
+                },
             )
+            set_csrf_cookie(response, token)
+            return response
         
         # Check if email exists
         if crud.get_user_by_email(db, email=email):
             print(f"Error: Email {email} already exists")
-            return templates.TemplateResponse(
+            token = generate_csrf_token()
+            response = templates.TemplateResponse(
                 "register.html",
                 {
                     "request": request,
                     "error": "Email already registered.",
                     "email": email,
-                    "username": username
-                }
+                    "username": username,
+                    "csrf_token": token,
+                },
             )
+            set_csrf_cookie(response, token)
+            return response
         
         # Check if username exists
         if crud.get_user_by_username(db, username=username):
             print(f"Error: Username {username} already exists")
-            return templates.TemplateResponse(
+            token = generate_csrf_token()
+            response = templates.TemplateResponse(
                 "register.html",
                 {
                     "request": request,
                     "error": "Username already taken.",
                     "email": email,
-                    "username": username
-                }
+                    "username": username,
+                    "csrf_token": token,
+                },
             )
+            set_csrf_cookie(response, token)
+            return response
         
         print("Creating new user...")
         # Create user
@@ -143,32 +181,43 @@ async def register(request: Request, db: Session = Depends(get_db)):
         print(f"User created successfully with ID: {db_user.id}")
         
         print("Redirecting to login page...")
-        return RedirectResponse(url="/login?registered=1", status_code=303)
+        response = RedirectResponse(url="/login?registered=1", status_code=303)
+        new_token = generate_csrf_token()
+        set_csrf_cookie(response, new_token)
+        return response
         
     except Exception as e:
         print(f"Error: {str(e)}")
         import traceback
         print(f"Traceback:\n{traceback.format_exc()}")
-        return templates.TemplateResponse(
+        token = generate_csrf_token()
+        response = templates.TemplateResponse(
             "register.html",
             {
                 "request": request,
                 "error": f"Registration failed: {str(e)}",
                 "email": email if 'email' in locals() else None,
-                "username": username if 'username' in locals() else None
-            }
+                "username": username if 'username' in locals() else None,
+                "csrf_token": token,
+            },
         )
+        set_csrf_cookie(response, token)
+        return response
 
 @app.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
     registered = request.query_params.get("registered")
-    return templates.TemplateResponse(
+    token = generate_csrf_token()
+    response = templates.TemplateResponse(
         "login.html",
         {
             "request": request,
-            "registered": registered
-        }
+            "registered": registered,
+            "csrf_token": token,
+        },
     )
+    set_csrf_cookie(response, token)
+    return response
 
 @app.post("/token")
 async def login(request: Request, db: Session = Depends(get_db)):
@@ -176,6 +225,10 @@ async def login(request: Request, db: Session = Depends(get_db)):
     try:
         form = await request.form()
         print(f"Form data: {dict(form)}")
+        form_csrf = form.get("csrf_token")
+        cookie_csrf = request.cookies.get(CSRF_COOKIE_NAME)
+        if not form_csrf or form_csrf != cookie_csrf:
+            raise HTTPException(status_code=403, detail="Invalid CSRF token")
         
         username = form.get("username")
         password = form.get("password")
@@ -185,24 +238,32 @@ async def login(request: Request, db: Session = Depends(get_db)):
         user = crud.get_user_by_username(db, username=username)
         if not user:
             print(f"User not found: {username}")
-            return templates.TemplateResponse(
+            token = generate_csrf_token()
+            response = templates.TemplateResponse(
                 "login.html",
                 {
                     "request": request,
-                    "error": "Incorrect username or password"
-                }
+                    "error": "Incorrect username or password",
+                    "csrf_token": token,
+                },
             )
+            set_csrf_cookie(response, token)
+            return response
         
         print(f"User found, verifying password...")
         if not auth.verify_password(password, user.hashed_password):
             print("Password verification failed")
-            return templates.TemplateResponse(
+            token = generate_csrf_token()
+            response = templates.TemplateResponse(
                 "login.html",
                 {
                     "request": request,
-                    "error": "Incorrect username or password"
-                }
+                    "error": "Incorrect username or password",
+                    "csrf_token": token,
+                },
             )
+            set_csrf_cookie(response, token)
+            return response
         
         print("Password verified successfully")
         access_token_expires = timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES)
@@ -218,21 +279,28 @@ async def login(request: Request, db: Session = Depends(get_db)):
             value=f"Bearer {access_token}",
             httponly=True,
             max_age=1800,
-            samesite="lax"
+            samesite="lax",
+            secure=True,
         )
+        new_token = generate_csrf_token()
+        set_csrf_cookie(response, new_token)
         return response
 
     except Exception as e:
         print(f"Error: {str(e)}")
         import traceback
         print(f"Traceback:\n{traceback.format_exc()}")
-        return templates.TemplateResponse(
+        token = generate_csrf_token()
+        response = templates.TemplateResponse(
             "login.html",
             {
                 "request": request,
-                "error": f"Login failed: {str(e)}"
-            }
+                "error": f"Login failed: {str(e)}",
+                "csrf_token": token,
+            },
         )
+        set_csrf_cookie(response, token)
+        return response
 
 
 @app.get("/logout")
@@ -269,14 +337,18 @@ async def dashboard(
             }
         )
 
-    return templates.TemplateResponse(
+    token = generate_csrf_token()
+    response = templates.TemplateResponse(
         "dashboard.html",
         {
             "request": request,
             "stats": stats,
             "monthly_entries": entries_dict,
+            "csrf_token": token,
         },
     )
+    set_csrf_cookie(response, token)
+    return response
 
 
 @app.get("/insights")
@@ -297,6 +369,12 @@ async def insights(
             "You are a trading coach. Based on these reasons traders succeeded, generate a concise list of best-practice Trading Tips. Format your response in Markdown.",
         )
         trading_tips = markdown.markdown(trading_tips_md)
+        trading_tips = bleach.clean(
+            trading_tips,
+            tags=bleach.sanitizer.ALLOWED_TAGS + ["p", "ul", "li", "strong", "em"],
+            attributes=bleach.sanitizer.ALLOWED_ATTRIBUTES,
+            strip=True,
+        )
     else:
         trading_tips = "No profit reasons submitted yet."
 
@@ -306,6 +384,12 @@ async def insights(
             "You are a trading mentor. Based on these reasons traders lost money, generate a concise Lessons Learned list of common mistakes and how to avoid them. Format your response in Markdown.",
         )
         lessons_learned = markdown.markdown(lessons_learned_md)
+        lessons_learned = bleach.clean(
+            lessons_learned,
+            tags=bleach.sanitizer.ALLOWED_TAGS + ["p", "ul", "li", "strong", "em"],
+            attributes=bleach.sanitizer.ALLOWED_ATTRIBUTES,
+            strip=True,
+        )
     else:
         lessons_learned = "No loss reasons submitted yet."
 
@@ -319,7 +403,12 @@ async def deposit_page(
     request: Request,
     current_user: models.User = Depends(auth.get_current_active_user)
 ):
-    return templates.TemplateResponse("deposit.html", {"request": request})
+    token = generate_csrf_token()
+    response = templates.TemplateResponse(
+        "deposit.html", {"request": request, "csrf_token": token}
+    )
+    set_csrf_cookie(response, token)
+    return response
 
 @app.post("/deposit")
 async def create_deposit(
@@ -329,6 +418,10 @@ async def create_deposit(
 ):
     try:
         form = await request.form()
+        form_csrf = form.get("csrf_token")
+        cookie_csrf = request.cookies.get(CSRF_COOKIE_NAME)
+        if not form_csrf or form_csrf != cookie_csrf:
+            raise HTTPException(status_code=403, detail="Invalid CSRF token")
         amount = float(form.get("amount"))
         date_str = form.get("date")
         date = datetime.strptime(date_str, "%Y-%m-%d").date()
@@ -336,23 +429,35 @@ async def create_deposit(
         deposit = schemas.DepositCreate(amount=amount, date=date)
         result = crud.create_deposit(db=db, deposit=deposit, user_id=current_user.id)
         
-        return RedirectResponse(url="/dashboard", status_code=303)
+        response = RedirectResponse(url="/dashboard", status_code=303)
+        new_token = generate_csrf_token()
+        set_csrf_cookie(response, new_token)
+        return response
     except Exception as e:
         print(f"Error creating deposit: {str(e)}")
-        return templates.TemplateResponse(
+        token = generate_csrf_token()
+        response = templates.TemplateResponse(
             "deposit.html",
             {
                 "request": request,
-                "error": f"Failed to create deposit: {str(e)}"
-            }
+                "error": f"Failed to create deposit: {str(e)}",
+                "csrf_token": token,
+            },
         )
+        set_csrf_cookie(response, token)
+        return response
 
 @app.get("/withdraw", response_class=HTMLResponse)
 async def withdraw_page(
     request: Request,
     current_user: models.User = Depends(auth.get_current_active_user)
 ):
-    return templates.TemplateResponse("withdraw.html", {"request": request})
+    token = generate_csrf_token()
+    response = templates.TemplateResponse(
+        "withdraw.html", {"request": request, "csrf_token": token}
+    )
+    set_csrf_cookie(response, token)
+    return response
 
 @app.post("/withdraw")
 async def create_withdrawal(
@@ -362,6 +467,10 @@ async def create_withdrawal(
 ):
     try:
         form = await request.form()
+        form_csrf = form.get("csrf_token")
+        cookie_csrf = request.cookies.get(CSRF_COOKIE_NAME)
+        if not form_csrf or form_csrf != cookie_csrf:
+            raise HTTPException(status_code=403, detail="Invalid CSRF token")
         amount = float(form.get("amount"))
         date_str = form.get("date")
         date = datetime.strptime(date_str, "%Y-%m-%d").date()
@@ -369,16 +478,23 @@ async def create_withdrawal(
         withdrawal = schemas.WithdrawalCreate(amount=amount, date=date)
         result = crud.create_withdrawal(db=db, withdrawal=withdrawal, user_id=current_user.id)
         
-        return RedirectResponse(url="/dashboard", status_code=303)
+        response = RedirectResponse(url="/dashboard", status_code=303)
+        new_token = generate_csrf_token()
+        set_csrf_cookie(response, new_token)
+        return response
     except Exception as e:
         print(f"Error creating withdrawal: {str(e)}")
-        return templates.TemplateResponse(
+        token = generate_csrf_token()
+        response = templates.TemplateResponse(
             "withdraw.html",
             {
                 "request": request,
-                "error": f"Failed to create withdrawal: {str(e)}"
-            }
+                "error": f"Failed to create withdrawal: {str(e)}",
+                "csrf_token": token,
+            },
         )
+        set_csrf_cookie(response, token)
+        return response
 
 @app.get("/daily-entry", response_class=HTMLResponse)
 async def daily_entry_page(
@@ -404,7 +520,12 @@ async def daily_entry_page(
                 entry_data = {"date": date_str, "profit": 0, "loss": 0, "reason_profit": "", "reason_loss": ""}
         except Exception as e:
             entry_data = None
-    return templates.TemplateResponse("daily_entry.html", {"request": request, "entry": entry_data})
+    token = generate_csrf_token()
+    response = templates.TemplateResponse(
+        "daily_entry.html", {"request": request, "entry": entry_data, "csrf_token": token}
+    )
+    set_csrf_cookie(response, token)
+    return response
 
 @app.post("/daily-entry")
 async def create_daily_entry(
@@ -414,6 +535,10 @@ async def create_daily_entry(
 ):
     try:
         form = await request.form()
+        form_csrf = form.get("csrf_token")
+        cookie_csrf = request.cookies.get(CSRF_COOKIE_NAME)
+        if not form_csrf or form_csrf != cookie_csrf:
+            raise HTTPException(status_code=403, detail="Invalid CSRF token")
         date_str = form.get("date")
         date = datetime.strptime(date_str, "%Y-%m-%d").date()
         profit = float(form.get("profit", 0) or 0)
@@ -430,16 +555,23 @@ async def create_daily_entry(
         )
         result = crud.create_daily_entry(db=db, entry=entry, user_id=current_user.id)
         
-        return RedirectResponse(url="/dashboard", status_code=303)
+        response = RedirectResponse(url="/dashboard", status_code=303)
+        new_token = generate_csrf_token()
+        set_csrf_cookie(response, new_token)
+        return response
     except Exception as e:
         print(f"Error creating daily entry: {str(e)}")
-        return templates.TemplateResponse(
+        token = generate_csrf_token()
+        response = templates.TemplateResponse(
             "daily_entry.html",
             {
                 "request": request,
-                "error": f"Failed to create daily entry: {str(e)}"
-            }
+                "error": f"Failed to create daily entry: {str(e)}",
+                "csrf_token": token,
+            },
         )
+        set_csrf_cookie(response, token)
+        return response
 
 @app.put("/daily-entry/{entry_id}")
 async def update_daily_entry(
@@ -459,8 +591,16 @@ async def reset_data(
     current_user: models.User = Depends(auth.get_current_active_user),
     db: Session = Depends(get_db)
 ):
+    form = await request.form()
+    form_csrf = form.get("csrf_token") if form else None
+    cookie_csrf = request.cookies.get(CSRF_COOKIE_NAME)
+    if not form_csrf or form_csrf != cookie_csrf:
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
     crud.reset_user_data(db, current_user.id)
-    return RedirectResponse(url="/dashboard", status_code=303)
+    response = RedirectResponse(url="/dashboard", status_code=303)
+    new_token = generate_csrf_token()
+    set_csrf_cookie(response, new_token)
+    return response
 
 @app.get("/test")
 async def test():

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,6 +34,7 @@
                     {% if not hide_reset %}
                     <form class="me-2" action="/reset-data" method="post"
                           onsubmit="return confirm('Are you sure you want to reset all data? This cannot be undone.');">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                         <button class="btn btn-danger btn-sm" type="submit">Reset Data</button>
                     </form>
                     {% endif %}

--- a/app/templates/daily_entry.html
+++ b/app/templates/daily_entry.html
@@ -15,6 +15,7 @@
                 {% endif %}
                 
                 <form action="/daily-entry" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <div class="mb-3">
                         <label for="date" class="form-label">Date</label>
                         <input type="date" class="form-control" id="date" name="date" required value="{{ entry.date if entry else '' }}">

--- a/app/templates/deposit.html
+++ b/app/templates/deposit.html
@@ -16,6 +16,7 @@
                     {% endif %}
                     
                     <form action="/deposit" method="post">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                         <div class="mb-3">
                             <label for="amount" class="form-label">Amount</label>
                             <div class="input-group">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -21,6 +21,7 @@
                 {% endif %}
                 
                 <form action="/token" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <div class="mb-3">
                         <label for="username" class="form-label">Username</label>
                         <input type="text" class="form-control" id="username" name="username" required>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -14,6 +14,7 @@
                 </div>
                 {% endif %}
                 <form action="/register" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <div class="mb-3">
                         <label for="email" class="form-label">Email</label>
                         <input type="email" class="form-control" id="email" name="email" required value="{{ email if email else '' }}">

--- a/app/templates/withdraw.html
+++ b/app/templates/withdraw.html
@@ -15,6 +15,7 @@
                 {% endif %}
                 
                 <form action="/withdraw" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <div class="mb-3">
                         <label for="amount" class="form-label">Amount</label>
                         <div class="input-group">

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ python-dotenv==1.0.0
 requests==2.31.0
 cryptography==41.0.5
 email-validator==2.1.0.post1
-markdown 
+markdown
+bleach==6.1.0


### PR DESCRIPTION
## Summary
- add `bleach` dependency
- sanitize Gemini AI output
- implement CSRF protection using double-submit cookie pattern
- add secure flag on auth cookies
- include CSRF tokens in all forms and templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684206a9780c83328bfd759c645a5180