### PR TITLE
Fix insights load error

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -191,8 +191,15 @@ document.addEventListener('DOMContentLoaded', function() {
     calendar.appendChild(currentRow);
 
     // Fetch trading insights via AJAX
-    fetch('/insights')
-        .then(response => response.json())
+    fetch('/insights', {
+            credentials: 'include'
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Failed to fetch insights');
+            }
+            return response.json();
+        })
         .then(data => {
             document.getElementById('trading-tips-content').innerHTML = data.trading_tips;
             document.getElementById('lessons-learned-content').innerHTML = data.lessons_learned;


### PR DESCRIPTION
## Summary
- ensure cookies are included when fetching dashboard insights
- check HTTP status before parsing JSON

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684243acf98c83329e9243abb6044fe4