### PR TITLE
Make cookie security configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ DB_PASSWORD=your_secure_password
 DB_NAME=trading_journal
 JWT_SECRET=your_jwt_secret_key
 GEMINI_API_KEY=your_gemini_api_key
+SECURE_COOKIES=true  # set to false when running over HTTP
 ```
 
 4. Build and start the containers:

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,9 @@ load_dotenv()
 # Initialize database
 init_db()
 
+# Use secure cookies by default, can be disabled for local development
+SECURE_COOKIES = os.getenv("SECURE_COOKIES", "true").lower() == "true"
+
 app = FastAPI()
 templates = Jinja2Templates(directory="app/templates")
 
@@ -37,7 +40,7 @@ def set_csrf_cookie(response: HTMLResponse | RedirectResponse, token: str) -> No
         CSRF_COOKIE_NAME,
         token,
         httponly=True,
-        secure=True,
+        secure=SECURE_COOKIES,
         samesite="lax",
         max_age=1800,
     )
@@ -280,7 +283,7 @@ async def login(request: Request, db: Session = Depends(get_db)):
             httponly=True,
             max_age=1800,
             samesite="lax",
-            secure=True,
+            secure=SECURE_COOKIES,
         )
         new_token = generate_csrf_token()
         set_csrf_cookie(response, new_token)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -191,8 +191,15 @@ document.addEventListener('DOMContentLoaded', function() {
     calendar.appendChild(currentRow);
 
     // Fetch trading insights via AJAX
-    fetch('/insights')
-        .then(response => response.json())
+    fetch('/insights', {
+            credentials: 'include'
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Failed to fetch insights');
+            }
+            return response.json();
+        })
         .then(data => {
             document.getElementById('trading-tips-content').innerHTML = data.trading_tips;
             document.getElementById('lessons-learned-content').innerHTML = data.lessons_learned;


### PR DESCRIPTION
## Summary
- allow disabling secure cookies for local development
- mention `SECURE_COOKIES` in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684243acf98c83329e9243abb6044fe4