### PR TITLE
Improve dashboard insights resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ A minimal, secure trading journal web application built with FastAPI and MySQL. 
 - Daily trading entries with profit/loss tracking
 - Interactive monthly calendar view
 - Dashboard with key statistics
-- AI-powered trading tips and lessons learned using Gemini AI
+- AI-powered trading tips and lessons learned using Gemini AI (falls back to simple summaries if the API is unavailable)
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- Google Gemini API key
+- Google Gemini API key (optional but recommended)
+- Without an API key the dashboard will generate basic summaries instead of AI responses
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- handle Gemini API failures by generating simple summaries
- clarify README about fallback behavior

## Testing
- `python -m py_compile app/main.py app/crud.py app/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6843025448f8833280b01f4b9c0b8721